### PR TITLE
FIX: Cannot read property 'toUpperCase' of undefined

### DIFF
--- a/lib/generateComponents.js
+++ b/lib/generateComponents.js
@@ -172,9 +172,9 @@ function optimizeSources (svgSources, config) {
 
         let filename
         if (config.camelCase) {
-          filename = camelCase(path.win32.basename(sanitizedContent, '.svg'))
+          filename = camelCase(path.win32.basename(content, '.svg'))
         } else {
-          filename = path.win32.basename(sanitizedContent, '.svg')
+          filename = path.win32.basename(content, '.svg')
         }
 
         filepath = path.normalize(path.dirname(sanitizedContent)).replace(/^\.\//, '').replace(/^\./, '')

--- a/lib/renderMarkup.js
+++ b/lib/renderMarkup.js
@@ -38,6 +38,12 @@ function filter (context, callback) {
   return [].filter.call(context, callback)
 }
 
+function forEach (arr, cb) {
+  for (let i = 0; i < arr.length; i++) {
+    cb(arr[i])
+  }
+}
+
 function iterateMarkup (markup, config, i = 0) {
   let tagName = markup.nodeName
 


### PR DESCRIPTION
To cause for this was that `filename` was always `undefined`. I am pretty sure this is the right fix since I have tested the script on OSX with and without target folder. I also added implementation of `forEach` since for some reason `forEach` was used like a global function but node threw an error for that. Can you guys @TheTekton @necinc confirm this? :)

Fixes #7 